### PR TITLE
Add support for LLVM/Clang 3.9

### DIFF
--- a/server/cmake/modules/FindLibClang.cmake
+++ b/server/cmake/modules/FindLibClang.cmake
@@ -15,7 +15,8 @@
 
 # most recent versions come first
 # http://llvm.org/apt/
-set(LIBCLANG_KNOWN_LLVM_VERSIONS 3.8.0 3.8
+set(LIBCLANG_KNOWN_LLVM_VERSIONS 3.9.0 3.9
+  3.8.0 3.8
   3.7.1 3.7.0 3.7
   3.6.2 3.6.1 3.6.0 3.6
   3.5.2 3.5.1 3.5.0 3.5


### PR DESCRIPTION
This PR adds support for latest trunk LLVM and Clang.
